### PR TITLE
Fix intermittent image push failures to GHCR

### DIFF
--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -32,7 +32,10 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
-        version: latest
+        # Pinning v0.9.1 for Buildx which uses BuildKit v0.10
+        # Buildx v0.10 uses BuildKit v0.11 which has a bug causing intermittent 
+        # failures pushing images to GHCR
+        version: v0.9.1
 
     - name: Login to DockerHub
       if: ${{ github.event_name == 'release' || github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}

--- a/.github/actions/setup-docker-environment/action.yaml
+++ b/.github/actions/setup-docker-environment/action.yaml
@@ -32,10 +32,11 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
-        # Pinning v0.9.1 for Buildx which uses BuildKit v0.10
-        # Buildx v0.10 uses BuildKit v0.11 which has a bug causing intermittent 
+        # Pinning v0.9.1 for Buildx and BuildKit v0.10.6
+        # BuildKit v0.11 which has a bug causing intermittent 
         # failures pushing images to GHCR
         version: v0.9.1
+        driver-opts: image=moby/buildkit:v0.10.6
 
     - name: Login to DockerHub
       if: ${{ github.event_name == 'release' || github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}


### PR DESCRIPTION
### Context

Pushing runner and controller images to GHCR were failing intermittently with the following error:

```text
[Build actions-runner-dind-ubuntu-20.04](https://github.com/actions-runner-controller/releases/actions/runs/3906536846/jobs/6674819314#step:6:3903)
buildx failed with: ERROR: failed to solve: failed to push ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest: failed to copy: io: read/write on closed pipe
```
This is due to a regression in BuildKit v0.11 which is used in Buildx v0.10.0 (latest). To resolve this, this PR will pin Buildx to v0.9.1 until this issue is resolved.

**Example:**
![CleanShot 2023-01-26 at 10 48 48](https://user-images.githubusercontent.com/568794/214805866-d48ab5d0-2b78-4490-a87e-44d2683b3455.png)

https://github.com/actions-runner-controller/releases/actions/runs/3906536846