### PR TITLE
Add concurrency limits to all workflows

### DIFF
--- a/.github/workflows/publish-arc.yaml
+++ b/.github/workflows/publish-arc.yaml
@@ -24,6 +24,10 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   release-controller:
     name: Release

--- a/.github/workflows/publish-canary.yaml
+++ b/.github/workflows/publish-canary.yaml
@@ -24,6 +24,10 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   canary-build:
     name: Build and Publish Canary Image

--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -36,6 +36,10 @@ env:
   TARGET_ORG: actions-runner-controller
   TARGET_REPO: actions-runner-controller
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build-runners:
     name: Build ${{ matrix.name }}-${{ matrix.os-name }}-${{ matrix.os-version }}


### PR DESCRIPTION
### Context

We should not have more than workflow run for each of those workflows. If we publish multiple times we should only publish the last in the queue.