### PR TITLE
Publish Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -59,6 +59,10 @@ jobs:
             os-name: ubuntu
             os-version: 22.04
             latest: "false"
+          - name: actions-runner
+            os-name: ubuntu
+            os-version: 24.04
+            latest: "false"
           - name: actions-runner-dind
             os-name: ubuntu
             os-version: 20.04
@@ -67,6 +71,10 @@ jobs:
             os-name: ubuntu
             os-version: 22.04
             latest: "false"
+          - name: actions-runner-dind
+            os-name: ubuntu
+            os-version: 24.04
+            latest: "false"
           - name: actions-runner-dind-rootless
             os-name: ubuntu
             os-version: 20.04
@@ -74,6 +82,10 @@ jobs:
           - name: actions-runner-dind-rootless
             os-name: ubuntu
             os-version: 22.04
+            latest: "false"
+          - name: actions-runner-dind-rootless
+            os-name: ubuntu
+            os-version: 24.04
             latest: "false"
 
     steps:


### PR DESCRIPTION
Support for Ubuntu 24.04 was added in https://github.com/actions/actions-runner-controller/pull/3598
The docker images were not published though, because the Github Action doesn't support Ubuntu 24.04 yet.
This PR adds Ubuntu 24.04 support for the publish action.